### PR TITLE
ci: update github token for bump action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Release
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
         run: npx semantic-release
 


### PR DESCRIPTION
Update GITHUB_TOKEN value of bump action in order to get the ORG_ACCESS_TOKEN with the correct priviledges.